### PR TITLE
Fix mission settings not working properly if correct Dynamic Mission Generator syntax is followed

### DIFF
--- a/Assets/Scripts/cipherMachine.cs
+++ b/Assets/Scripts/cipherMachine.cs
@@ -413,7 +413,7 @@ public class cipherMachine : MonoBehaviour
             string description = Application.isEditor ? EditorMissionSettings : Game.Mission.Description;
             if (description == null)
                 return null;
-            var matches = Regex.Matches(description, @"^(?:// )?\[Cipher ?Machine\] (.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            var matches = Regex.Matches(description, @"^(?:\/{2,3} )?\[Cipher ?Machine\] (.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             var warnings = new List<string>();
             for (var i = 0; i < matches.Count; i++)
             {


### PR DESCRIPTION
DMG expects 2 to 3 forward slashes before a mission description line. Additionally escaped the forward slashes for good measure.

I have also confirmed that this change does not affect mission settings in actual missions [via Cipher Machine practice missions]